### PR TITLE
Fix redirect_uri_mismatch error

### DIFF
--- a/src/Auth/Source/Connect.php
+++ b/src/Auth/Source/Connect.php
@@ -74,7 +74,7 @@ class sspmod_openidconnect_Auth_Source_Connect extends SimpleSAML_Auth_Source {
     return array(
       'client_info' => array(
         'client_id' => $this->clientId,
-        'redirect_uri' => SimpleSAML_Module::getModuleURL('openidconnect/resume.php', array('State' => $stateId)),
+        'redirect_uri' => SimpleSAML_Module::getModuleURL('openidconnect/resume.php'),
         'authorization_endpoint' => $this->authEndpoint,
         'token_endpoint' => $this->tokenEndpoint,
         'user_info_endpoint' => $this->userInfoEndpoint,
@@ -97,7 +97,7 @@ class sspmod_openidconnect_Auth_Source_Connect extends SimpleSAML_Auth_Source {
     $stateId = SimpleSAML_Auth_State::saveState($state, 'openidconnect:Connect', TRUE);
     $flow = new Basic($this->getConfig($stateId));
     $uri = $flow->getAuthorizationRequestUri($this->scope);
-    SimpleSAML_Utilities::redirectTrustedURL($uri);
+    SimpleSAML_Utilities::redirectTrustedURL($uri, array('state' => $stateId));
   }
 
   /**
@@ -159,8 +159,8 @@ class sspmod_openidconnect_Auth_Source_Connect extends SimpleSAML_Auth_Source {
    */
   public static function resume() {
     $request = Request::fromString($_SERVER['REQUEST_METHOD'] . ' ' . self::requesturi());
-    if (!$stateId = $request->getQuery('State')) {
-      throw new SimpleSAML_Error_BadRequest('Missing "State" parameter.');
+    if (!$stateId = $request->getQuery('state')) {
+      throw new SimpleSAML_Error_BadRequest('Missing "state" parameter.');
     }
     $state = SimpleSAML_Auth_State::loadState($stateId, 'openidconnect:Connect');
 


### PR DESCRIPTION
This PR aims to fix the `redirect_uti_mismatch` error caused by the inclusion of the `State` param in the `redirect_uri` being passed. You can see an example of this issue when using the OIDC Authentication Source against Google's OAuth 2.0 APIs in the screenshot attached. 

<img width="936" alt="ssp-oidc-error-redirect_uri_mismatch" src="https://cloud.githubusercontent.com/assets/1188170/12991482/211dd2a0-d118-11e5-9e24-e6cc4350c186.png">

As described in the [OIDC Basic Client Implementer's Guide 1.0](https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters):

> This URI MUST exactly match one of the Redirection URI values for the Client pre-registered at the OpenID Provider

The proposed fix is to pass the `state` param in the call to `SimpleSAML_Utilities::redirectTrustedURL`. Please note that the parameter name has changed from `State` to `state` (note letter case) to match the specs:

> Opaque value used to maintain state between the request and the callback. Typically, Cross-Site Request Forgery (CSRF, XSRF) mitigation is done by cryptographically binding the value of this parameter with a browser cookie.

After applying this change, the OIDC Auth Source seems to work as expected.

@bradjones1 many thanks for this useful module and hope it gets added to SimpleSAMLphp's core modules soon.
